### PR TITLE
Redesign main-content as modular panels

### DIFF
--- a/frontend/css/components/chat.css
+++ b/frontend/css/components/chat.css
@@ -4,13 +4,13 @@
   min-height: 0;
   overflow-y: auto;
   padding: 0.5rem;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.02);
   border: 1px solid var(--border);
   border-radius: 4px;
 }
 
 .dark-mode .chat-messages {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .chat-msg {
@@ -108,18 +108,18 @@
 
 .chat-form {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   margin-top: 0.5rem;
 }
 
 .chat-input {
   flex: 1;
-  padding: 0.5rem 0.625rem;
+  padding: 0.375rem 0.625rem;
   border-radius: 4px;
   border: 1px solid var(--border);
   background: transparent;
   color: var(--text);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .chat-input:focus {
@@ -128,13 +128,13 @@
 }
 
 .chat-send-btn {
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.75rem;
   border: 1px solid var(--border);
   border-radius: 4px;
   background: transparent;
   color: var(--text);
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   transition: background 0.2s, color 0.2s;
 }
 

--- a/frontend/css/components/notes.css
+++ b/frontend/css/components/notes.css
@@ -2,11 +2,12 @@
 .notes-list {
   list-style: none;
   padding: 0;
+  margin: 0;
 }
 
 .note-item {
-  padding: 1rem 0;
-  border-bottom: 1px solid var(--border);
+  padding: 0.625rem 0;
+  border-bottom: 1px dashed var(--border);
 }
 
 .note-item:last-child {
@@ -15,10 +16,12 @@
 
 .note-link {
   font-weight: 500;
+  font-size: 0.9375rem;
   color: var(--text);
   text-decoration: none;
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
+  line-height: 1.35;
   transition: color 0.2s;
 }
 
@@ -28,20 +31,23 @@
 
 .note-meta {
   display: flex;
-  font-size: 0.75rem;
+  align-items: center;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
+  gap: 0.5rem;
 }
 
 .note-date {
-  margin-right: var(--space-3);
-  font-family: var(--font-accent);
+  font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  letter-spacing: 0.02em;
 }
 
 .note-category {
   display: inline-block;
-  padding: 0 0.5rem;
+  padding: 0.0625rem 0.375rem;
   background: var(--accent-subtle);
-  border-radius: 4px;
+  border-radius: 3px;
+  font-size: 0.6875rem;
 }
 
 .preview-btn {
@@ -121,15 +127,15 @@
 
 .notes-search {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
 }
 
 .notes-search-input {
   flex: 1;
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.625rem;
   font-family: var(--font);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text);
   background: var(--bg);
   border: 1px solid var(--border);
@@ -147,7 +153,7 @@
 }
 
 .notes-search-btn {
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.625rem;
   background: var(--accent);
   border: none;
   border-radius: 4px;

--- a/frontend/css/components/timeline.css
+++ b/frontend/css/components/timeline.css
@@ -13,8 +13,8 @@
 
 .timeline-nav {
   flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border: none;
   background: var(--accent);
   border-radius: 50%;
@@ -36,69 +36,83 @@
 }
 
 .timeline-nav svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
 }
 
 .timeline {
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
-  gap: 1.5rem;
+  gap: 0.75rem;
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  padding: 0.5rem 0;
+  padding: 0.25rem 0;
 }
 
 .timeline::-webkit-scrollbar {
   display: none;
 }
 
+/* Each job is its own small panel - a physical card on a rail */
 .timeline-item {
-  flex: 0 0 calc((100% - 3rem) / 3);
+  flex: 0 0 calc((100% - 1.5rem) / 3);
   scroll-snap-align: start;
-  padding: 1rem;
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  transition: border-color 0.15s;
+}
+
+.timeline-item:hover {
+  border-color: var(--accent);
 }
 
 .timeline-header {
   display: flex;
   align-items: flex-start;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .timeline-logo {
-  width: 70px;
+  width: 44px;
+  height: 44px;
   object-fit: contain;
-  margin-right: 1rem;
+  margin-right: 0.75rem;
+  flex-shrink: 0;
 }
 
 .timeline-details {
   flex: 1;
+  min-width: 0;
 }
 
 .timeline-position {
-  font-size: 1.125rem;
+  font-size: 0.9375rem;
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  margin: 0 0 0.125rem 0;
+  line-height: 1.3;
 }
 
 .timeline-company {
   font-family: var(--font-accent);
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--text);
+  margin: 0 0 0.25rem 0;
 }
 
 .timeline-period,
 .timeline-location {
-  font-family: var(--font-accent);
-  font-size: 0.75rem;
+  font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
   display: inline;
   margin: 0;
+  letter-spacing: 0.02em;
 }
 
 .timeline-period {
@@ -106,25 +120,61 @@
 }
 
 .timeline-period::before {
-  content: "•";
+  content: "·";
   margin: 0 var(--space-2);
   opacity: 0.6;
 }
 
 .timeline-description {
-  font-size: 0.875rem;
-  line-height: 1.7;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  margin: 0.5rem 0 0 0;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--border);
 }
 
+/* Areas of Study as a tag cloud - many labels, little space,
+   like the contents label on a piece of equipment */
 .areas-list {
   list-style: none;
   padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
 }
 
+.areas-list li {
+  margin: 0;
+}
+
+.areas-list li a {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.areas-list li a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+/* Education - tight, inline metadata like a spec sheet */
 .education-item {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--border);
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .education-item:last-child {
@@ -132,39 +182,44 @@
 }
 
 .education-degree {
-  font-size: 1.125rem;
+  font-size: 0.9375rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.125rem 0;
+  line-height: 1.3;
 }
 
 .education-school {
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text);
+  margin: 0 0 0.375rem 0;
 }
 
 .education-dates {
-  font-family: var(--font-accent);
-  font-size: 0.75rem;
+  font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
-  margin-bottom: 0.75rem;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: 0.02em;
 }
 
 .education-gpa {
-  font-weight: 600;
-  font-size: 0.875rem;
-  margin-bottom: 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  margin: 0 0 0.375rem 0;
 }
 
 .education-focus {
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin-bottom: 0.75rem;
+  margin: 0 0 0.5rem 0;
   font-style: italic;
 }
 
 .education-courses {
   font-size: 0.75rem;
-  line-height: 1.7;
+  line-height: 1.6;
   color: var(--text-secondary);
+  margin: 0;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--border);
 }
-

--- a/frontend/css/layout/grid.css
+++ b/frontend/css/layout/grid.css
@@ -10,7 +10,7 @@
   flex-direction: column;
   min-width: 0;
   overflow-x: hidden;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 cloth-content {
@@ -19,7 +19,8 @@ cloth-content {
   cursor: grab;
   touch-action: pan-y pinch-zoom;
   pointer-events: auto;
-  font-size: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.6;
 }
 
 cloth-content:active {
@@ -34,22 +35,36 @@ body:has(.right-sidebar.mobile-open) .main-content {
   margin-right: var(--right-sidebar-width);
 }
 
+/* Each section is a self-contained panel - like a module on a piece
+   of industrial design (consistent borders, subtle radius, uniform
+   internal rhythm). */
 .section {
   margin-bottom: 0;
-  padding: 1rem;
+  padding: 0.875rem 1rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  position: relative;
 }
 
+/* Section title as a small tracked panel label. Subordinate to
+   content, like the engraved labels on a hi-fi. */
 .section-title {
-  font-size: 1.25rem;
+  font-size: 0.6875rem;
   font-weight: 600;
-  margin-bottom: 1rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
 }
 
 /* Grid row containers */
 .grid-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
   align-items: stretch;
 }
 
@@ -60,7 +75,8 @@ body:has(.right-sidebar.mobile-open) .main-content {
 .grid-row-equal {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
+  align-items: stretch;
 }
 
 .grid-row-equal>.section {
@@ -71,14 +87,16 @@ body:has(.right-sidebar.mobile-open) .main-content {
 .grid-col-stack {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
+  min-height: 0;
 }
 
 .grid-col-stack>.section {
   flex: 1;
+  min-height: 0;
 }
 
-/* Visitors and Chat sections - same height, scrollable content */
+/* Services / Visitors / Chat stack - fixed height matches About */
 #visitors,
 #chat {
   display: flex;
@@ -87,7 +105,7 @@ body:has(.right-sidebar.mobile-open) .main-content {
   overflow: hidden;
 }
 
-/* When stacked alongside About, equalize heights via flex instead of fixed 30rem */
+/* When stacked alongside About, equalize via flex */
 .grid-col-stack > #services,
 .grid-col-stack > #visitors,
 .grid-col-stack > #chat {
@@ -110,19 +128,20 @@ body:has(.right-sidebar.mobile-open) .main-content {
 
 /* Align header areas */
 #visitors .section-title,
-#chat .section-title {
+#chat .section-title,
+#services .section-title {
   flex-shrink: 0;
-  margin-bottom: 0.5rem;
 }
 
 #visitor-stats,
 .chat-status {
   flex-shrink: 0;
-  height: 1.25rem;
-  line-height: 1.25rem;
-  font-size: 0.75rem;
+  height: 1.125rem;
+  line-height: 1.125rem;
+  font-size: 0.6875rem;
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Hide empty visitor-list */
@@ -130,7 +149,7 @@ body:has(.right-sidebar.mobile-open) .main-content {
   display: none;
 }
 
-/* Visitor filters at top, chat form at bottom - same height/spacing */
+/* Visitor filters at top, chat form at bottom - same rhythm */
 .visitor-filters {
   flex-shrink: 0;
   margin-bottom: 0.5rem;
@@ -141,17 +160,24 @@ body:has(.right-sidebar.mobile-open) .main-content {
 }
 
 #services-stats {
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
+  font-variant-numeric: tabular-nums;
 }
 
 #services-content {
-  height: 320px;
+  height: auto;
+  flex: 1;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.dark-mode #services-content {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 #canvas {
@@ -175,11 +201,11 @@ body:has(.right-sidebar.mobile-open) .main-content {
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.5rem;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.02);
 }
 
 .dark-mode #recent-visitor-list {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 /* Services table skeleton loading styles */
@@ -214,8 +240,9 @@ body:has(.right-sidebar.mobile-open) .main-content {
 
 .section-description {
   color: var(--text-secondary);
-  margin-bottom: 1.5rem;
-  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
 }
 
 .section-description-spaced {
@@ -228,9 +255,12 @@ body:has(.right-sidebar.mobile-open) .main-content {
 
 .line-count-display {
   display: inline-block;
-  font-family: monospace;
+  font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+  font-size: 0.875rem;
   text-align: right;
-  margin: 0 50%;
+  margin: 1rem 50% 1rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
 }
 
 .line-count-display>div:nth-child(2) {
@@ -240,28 +270,35 @@ body:has(.right-sidebar.mobile-open) .main-content {
 
 .line-count-display>div:nth-child(3) {
   padding-top: 0.2em;
+  color: var(--text);
+  font-weight: 600;
 }
 
 .areas-of-study-title {
-  font-size: 1.125rem;
+  font-size: 1rem;
   font-weight: 600;
-  margin: 2rem 0 1rem 0;
+  margin: 1.5rem 0 0.75rem 0;
   color: var(--text);
 }
 
+/* About panel - compact, scrolls if content overflows */
 #about {
-  margin-bottom: 1.5rem;
-  height: 40rem;
+  margin-bottom: 0;
+  height: 32rem;
   overflow-y: auto;
 }
 
+/* Match right stack to About height */
 .grid-col-stack:has(> #services) {
-  height: 40rem;
+  height: 32rem;
 }
 
 .about-text {
-  font-size: 1.125rem;
-  line-height: 1.6;
-  margin-bottom: 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  margin-bottom: 1rem;
 }
 
+.about-text:last-child {
+  margin-bottom: 0;
+}

--- a/frontend/css/responsive.css
+++ b/frontend/css/responsive.css
@@ -123,13 +123,8 @@
     grid-template-columns: 1fr;
   }
 
-  .section-title {
-    font-size: 1.125rem;
-    margin-bottom: 1rem;
-  }
-
   .section {
-    padding: 0.75rem;
+    padding: 0.75rem 0.875rem 0.875rem;
   }
 
   .timeline-item {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -289,9 +289,9 @@
         </div>
       </div>
 
-      <!-- Row 3: Notes + Education | About + Areas of Study (50/50) -->
+      <!-- Row 3: Notes | (Education + Areas of Study) -->
       <div class="grid-row-equal">
-        <!-- Left column: Notes + Education stacked -->
+        <!-- Left column: Notes (fills column) -->
         <div class="grid-col-stack">
           <section id="notes-preview" class="section">
             <h2 class="section-title">Recent Notes</h2>
@@ -309,6 +309,20 @@
                 <p class="notes-placeholder">Loading...</p>
               </li>
             </ul>
+          </section>
+        </div>
+
+        <!-- Right column: Preview (hidden) + Education + Areas of Study -->
+        <div class="grid-col-stack" id="right-col-stack">
+
+          <section id="note-inline-preview" class="section note-inline-preview" style="display: none;">
+            <div class="note-inline-header">
+              <h2 class="section-title note-inline-title">Preview</h2>
+              <button class="note-inline-close" aria-label="Close preview">&times;</button>
+            </div>
+            <div class="note-inline-content">
+              <div class="note-inline-loading">Loading...</div>
+            </div>
           </section>
 
           <section id="education" class="section">
@@ -328,20 +342,6 @@
                 Design, Natural Language Processing
               </p>
             </article>
-          </section>
-        </div>
-
-        <!-- Right column: stacked sections -->
-        <div class="grid-col-stack" id="right-col-stack">
-
-          <section id="note-inline-preview" class="section note-inline-preview" style="display: none;">
-            <div class="note-inline-header">
-              <h2 class="section-title note-inline-title">Preview</h2>
-              <button class="note-inline-close" aria-label="Close preview">&times;</button>
-            </div>
-            <div class="note-inline-content">
-              <div class="note-inline-loading">Loading...</div>
-            </div>
           </section>
 
           <section id="areas-of-study" class="section">


### PR DESCRIPTION
## Summary

Redesigns the `main-content` of `frontend/index.html` around a physical/industrial-design aesthetic — each `<section>` is now a discrete panel (thin border, 6px radius, uniform padding) and section titles become small tracked uppercase labels, subordinate to content. Layout is tighter without squishing sections together.

- **Panels, not paragraphs** — every section gets a 1px border, 6px radius, consistent internal padding. Section titles shrink to small tracked uppercase labels (0.6875rem, 0.14em tracking) with a thin separator, so content leads.
- **Tighter rhythm** — main gap 1rem → 0.75rem. About height 40rem → 32rem. cloth-content font-size 1.5rem → 1rem. about-text 1.125rem → 0.9375rem. Monospaced tabular-nums for dates and stat numbers.
- **Areas of Study → chip cloud** — flex-wrap pills instead of a vertical list; huge compactness win.
- **Education compacted** — tighter spacing, mono date, dashed separator to coursework.
- **Timeline cards as pieces on a rail** — each job gets a subtle border + hover accent, smaller square logos, dashed separator before the description.
- **Notes row rebalanced** — Notes occupies its own column beside a right stack of Education + Areas of Study, so both columns carry similar weight.
- **Mobile fix** — removed an override in `responsive.css` that was reverting the small-label section title treatment under 640px.

## Test plan

- [ ] Desktop: About row (About | Services/Visitors/Chat stack) aligns at 32rem, nothing cramped, chat input visible
- [ ] Desktop: Notes column matches Education + Areas of Study stack in height without obvious empty space
- [ ] Areas of Study chips wrap cleanly and hover states work
- [ ] Timeline cards scroll horizontally with snap + hover border stays consistent
- [ ] Dark mode reads well on all panels (borders visible, subtle backgrounds correct)
- [ ] Mobile (<640px) single-column layout still works; section titles remain small uppercase labels
- [ ] Note preview (click an eye icon) still opens in the right column above Education